### PR TITLE
Remove -Werror from compiler flags

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@
 #File name: makefile
 
 CXX = g++
-CFLAGS = -Wall -Werror
+CFLAGS = -Wall
 SRC = driver.cpp
 OBJ = $(SRC:.cpp=.o)
 DEPS = listinterface.h linkedlist.h node.h


### PR DESCRIPTION
Removed -Werror from compiler flag list in the makefile so that warnings stay warnings instead of elevate to errors.